### PR TITLE
System{Info,Logs}: use sh instead of bash

### DIFF
--- a/poms/api/views.py
+++ b/poms/api/views.py
@@ -628,7 +628,7 @@ class SystemInfoViewSet(AbstractViewSet):
         )
 
         shell_cmd = "ps aux | grep [b]ackend"
-        c = pexpect.spawn("/bin/bash", ["-c", shell_cmd])
+        c = pexpect.spawn("sh", ["-c", shell_cmd])
         pexpect_result = c.read()
 
         celery_worker_state = True
@@ -647,7 +647,7 @@ class SystemInfoViewSet(AbstractViewSet):
         )
 
         shell_cmd = "ps aux | grep [d]jango_celery_beat"
-        c = pexpect.spawn("/bin/bash", ["-c", shell_cmd])
+        c = pexpect.spawn("sh", ["-c", shell_cmd])
         pexpect_result = c.read()
 
         celery_beat_state = True
@@ -678,7 +678,7 @@ class SystemInfoViewSet(AbstractViewSet):
         if not getattr(self, "pip_freeze_data", None):
             self.pip_freeze_data = {"all": {}, "django": "-"}
 
-            c = pexpect.spawn("/bin/bash", ["-c", "pip3 freeze"])
+            c = pexpect.spawn("sh", ["-c", "pip3 freeze"])
 
             for freeze_item in c.readlines():
                 if freeze_item:
@@ -871,7 +871,7 @@ class SystemLogsViewSet(AbstractViewSet):
         result = {}
 
         shell_cmd = "ls -la /var/log/finmars/backend/  | awk '{print $9}'"
-        c = pexpect.spawn("/bin/bash", ["-c", shell_cmd])
+        c = pexpect.spawn("sh", ["-c", shell_cmd])
         pexpect_result = c.read().decode("utf-8")
 
         # items = pexpect_result.split('\')


### PR DESCRIPTION
Bash is not available in Alpine images. In
bb1ce0a0388a5b0ee90b4ceb669ec39dc567f395, the Docker image was changed to Alpine from Debian, which caused 500 errors in the SystemInfoViewSet and SystemLogsViewSet.

Now it calls "sh" instead of "/bin/bash", which should be more portable across different distributions. Since no bash-exclusive features were used, this was trivial.

Fixes finmars-platform/finmars-core#62