### PR TITLE
utils/attr_is_relation: add portfolio_type to relation set

### DIFF
--- a/poms/common/utils.py
+++ b/poms/common/utils.py
@@ -885,6 +885,7 @@ def attr_is_relation(content_type_key: str, attribute_key: str) -> bool:
         "group",
         "pricing_policy",
         "portfolio",
+        "portfolio_type",
         "transaction_type",
         "transaction_currency",
         "settlement_currency",


### PR DESCRIPTION
/api/v1/portfolios/portfolio/ev-group/ returned `group_name` and `group_identifier` as numbers instead of strings. Other endpoints, like /api/v1/instruments/instrument/ev-group/ return strings correctly. These numerical values were then shown in the UI, as showcased in https://github.com/finmars-platform/finmars-core/issues/149#issuecomment-3896996252.

By marking `portfolio_type` as a relation, it now correctly shows the names when invoking this API endpoint.