### PR TITLE
Fix Sentry init: make DSN env-driven and off by default

### DIFF
--- a/poms_app/settings.py
+++ b/poms_app/settings.py
@@ -812,14 +812,14 @@ REDOC_SETTINGS = {
 
 VAULT_TOKEN = ENV_STR("VAULT_TOKEN", None)
 
-SENTRY_DSN = ENV_STR("SENTRY_DSN", "https://bbc302cc7bd5bbb2719b030ace26222a@sentry.finmars.com/2")
-if SERVER_TYPE != "local":
+SENTRY_DSN = ENV_STR("SENTRY_DSN", "")
+if SERVER_TYPE != "local" and SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         environment=SERVER_TYPE,
-        traces_sample_rate=1.0,
+        traces_sample_rate=float(ENV_STR("SENTRY_TRACES_SAMPLE_RATE", "0.1")),
         send_default_pii=True,
-        profiles_sample_rate=1.0,
+        profiles_sample_rate=float(ENV_STR("SENTRY_PROFILES_SAMPLE_RATE", "0.1")),
     )
 
 INSTRUMENT_TYPE_PREFIX = ENV_STR(


### PR DESCRIPTION
## Problem
`sentry.finmars.com` (135.125.137.70, OVH) is unreachable — TCP connect to :443 times out (30s). Sentry was initialized with a hardcoded DSN and `traces_sample_rate=1.0`/`profiles_sample_rate=1.0`, so every request tried to ship an envelope to the dead endpoint. This flooded the backend web pods with retrying connection timeouts and slowed API responses.

## Change
- `SENTRY_DSN` now defaults to empty; Sentry initializes only when a DSN is explicitly provided (`SERVER_TYPE != "local" and SENTRY_DSN`).
- `traces_sample_rate` / `profiles_sample_rate` are now env-driven (`SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_PROFILES_SAMPLE_RATE`), defaulting to `0.1` instead of `1.0`.

## Effect
With no `SENTRY_DSN` configured, Sentry stays disabled — no calls to the dead endpoint. To re-enable, set `SENTRY_DSN` to a live endpoint (and optionally tune the sample rates via env).