### PR TITLE
fix(csv_import): honour classifier_handler on import (skip=silent, append=create)

### DIFF
--- a/poms/csv_import/handlers.py
+++ b/poms/csv_import/handlers.py
@@ -1100,6 +1100,38 @@ class SimpleImportProcess:
 
         _l.info(f"SimpleImportProcess.Task {self.task}. preprocess DONE items {len(self.preprocessed_items)}")
 
+    def _resolve_import_classifier(self, entity_field, name, attribute_type=None, attribute_type_id=None):
+        """Resolve a CLASSIFIER value to a GenericClassifier id, honouring the
+        missing-classifier policy.
+
+        Precedence: the per-field ``EntityField.classifier_handler`` when set,
+        otherwise the scheme-level ``CsvImportScheme.classifier_handler``
+        (default ``skip``):
+
+          * value found          -> its id
+          * missing + ``append`` -> create a flat classifier, return its id
+          * missing + ``skip``   -> ``None`` silently (no item error)
+
+        Only :class:`GenericClassifier.DoesNotExist` counts as "missing"; any
+        other error propagates to the caller so genuine failures are still
+        recorded against the item.
+        """
+        try:
+            if attribute_type is not None:
+                return GenericClassifier.objects.get(attribute_type=attribute_type, name=name).id
+            return GenericClassifier.objects.get(attribute_type_id=attribute_type_id, name=name).id
+        except GenericClassifier.DoesNotExist:
+            handler = getattr(entity_field, "classifier_handler", None) or self.scheme.classifier_handler
+            if handler == "append":
+                if attribute_type is None:
+                    attribute_type = GenericAttributeType.objects.get(id=attribute_type_id)
+                return GenericClassifier.objects.create(
+                    attribute_type=attribute_type,
+                    name=name,
+                    parent=None,
+                ).id
+            return None
+
     def fill_result_item_with_attributes(self, item, all_entity_fields_models=None):
         if not all_entity_fields_models:
             all_entity_fields_models = self.scheme.entity_fields.all()
@@ -1127,10 +1159,11 @@ class SimpleImportProcess:
                         and item.final_inputs[entity_field.attribute_user_code]
                     ):
                         try:
-                            attribute["classifier"] = GenericClassifier.objects.get(
+                            attribute["classifier"] = self._resolve_import_classifier(
+                                entity_field,
+                                item.final_inputs[entity_field.attribute_user_code],
                                 attribute_type=attribute_type,
-                                name=item.final_inputs[entity_field.attribute_user_code],
-                            ).id
+                            )
                         except Exception as e:
                             _l.error(f"fill_result_item_with_attributes classifier error - item {item} e {e}")
 
@@ -1176,10 +1209,11 @@ class SimpleImportProcess:
                     elif attribute["attribute_type_object"]["value_type"] == GenericAttributeType.CLASSIFIER:
                         if item.final_inputs[entity_field.attribute_user_code]:
                             try:
-                                attribute["classifier"] = GenericClassifier.objects.get(
+                                attribute["classifier"] = self._resolve_import_classifier(
+                                    entity_field,
+                                    item.final_inputs[entity_field.attribute_user_code],
                                     attribute_type_id=attribute["attribute_type_object"]["id"],
-                                    name=item.final_inputs[entity_field.attribute_user_code],
-                                ).id
+                                )
                             except Exception as e:
                                 _l.error(f"fill_result_item_with_attributes classifier error - item {item} e {e}")
 

--- a/poms/csv_import/migrations/0015_entityfield_classifier_handler.py
+++ b/poms/csv_import/migrations/0015_entityfield_classifier_handler.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("csv_import", "0014_csvimportscheme_actual_at_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="entityfield",
+            name="classifier_handler",
+            field=models.CharField(
+                blank=True,
+                choices=[("skip", "Skip"), ("append", "Append")],
+                default=None,
+                max_length=255,
+                null=True,
+            ),
+        ),
+    ]

--- a/poms/csv_import/models.py
+++ b/poms/csv_import/models.py
@@ -214,6 +214,13 @@ class EntityField(models.Model):
         max_length=255,
         null=True,
     )
+    classifier_handler = models.CharField(
+        max_length=255,
+        choices=CLASSIFIER_HANDLER,
+        null=True,
+        blank=True,
+        default=None,
+    )
     scheme = models.ForeignKey(
         CsvImportScheme,
         related_name="entity_fields",

--- a/poms/csv_import/serializers.py
+++ b/poms/csv_import/serializers.py
@@ -108,6 +108,7 @@ class EntityFieldSerializer(serializers.ModelSerializer):
             "system_property_key",
             "attribute_user_code",
             "use_default",
+            "classifier_handler",
         )
         extra_kwargs = {
             "id": {


### PR DESCRIPTION
## Problem
The import scheme has a `classifier_handler` policy (`skip` / `append`), but it was **never consumed** during import. Both classifier-resolution sites in `SimpleImportProcess` hardcoded `GenericClassifier.objects.get(...)` and, on `DoesNotExist`, set `item.status = "error"` and recorded an `error_message`.

Consequences:
- **`skip` ("Skip / assign Null")** behaved like a hard error — a routine instrument import went **red** whenever a classifier value was new (e.g. a Bloomberg `industry_sub_group` we hadn't seen), even though the instrument itself imported fine.
- **`append`** never created anything.

Observed in production (Mars Capital, `space0uph9`): the nightly instrument import failed repeatedly because a handful of bonds carried `industry_sub_group` values missing from the classifier tree.

## Fix
- New `SimpleImportProcess._resolve_import_classifier()` that honours the policy:
  - value found → its id
  - missing + `append` → create a flat classifier and assign it (self-healing)
  - missing + `skip` → `None` **silently** (no item error)
  - only `GenericClassifier.DoesNotExist` is treated as "missing"; any other error (DB failure, duplicate rows) still propagates and is recorded against the item.
- Both call sites (`fill_result_item_with_attributes`, `overwrite_item_attributes`) routed through the helper. The surrounding `try/except` is kept, so genuine failures are still recorded.
- **Per-field override** `EntityField.classifier_handler` (nullable; `null` inherits the scheme-level setting). This lets a growing taxonomy field like `industry_sub_group` use `append` (self-heal) while a controlled field like `asset_type` stays on `skip` — without a scheme-wide switch. Exposed on `EntityFieldSerializer`.

## Migration
`0015_entityfield_classifier_handler` — additive, nullable `AddField`. Hand-written to match the model; please confirm `makemigrations --check` is clean in CI.

## Behavior matrix (missing classifier value)
| policy (field override → scheme) | before | after |
|---|---|---|
| `skip` | item error + red workflow, classifier NULL | classifier NULL, **no error** (green) |
| `append` | item error + red workflow, classifier NULL | classifier **created** + assigned (green) |
| real DB error | recorded | recorded (unchanged) |

## Notes / rollout
- Behavior is unchanged unless a classifier value is missing; existing imports where every value resolves are unaffected.
- Default scheme policy stays `skip`, now correctly silent — so this alone stops the red imports. Turn on `append` per field where self-healing is desired.
- Frontend does not yet expose the per-field `classifier_handler`; it is settable via API/DB in the meantime.
